### PR TITLE
Add BotZilla Telegram bot skeleton with Mongo storage and onboarding

### DIFF
--- a/botzilla/.env.example
+++ b/botzilla/.env.example
@@ -1,0 +1,8 @@
+BOT_TOKEN=replace_me
+DB_BACKEND=mongo # or sqlite
+SQLITE_PATH=botzilla.db
+MONGO_URI=mongodb://localhost:27017/botzilla
+ADMIN_IDS=123456789,987654321
+DEVELOPER_IDS=1122334455
+PUBLIC_URL=https://your-ngrok-id.ngrok-free.app
+LOG_LEVEL=INFO

--- a/botzilla/Makefile
+++ b/botzilla/Makefile
@@ -1,0 +1,15 @@
+.PHONY: run set-webhook test bundle
+
+run:
+	python app.py
+
+set-webhook:
+	PUBLIC_URL=$(PUBLIC_URL) BOT_TOKEN=$$BOT_TOKEN python scripts/set_webhook.py
+
+test:
+	pytest -q
+
+# Create a zip of the repo (no git needed)
+bundle:
+	zip -r botzilla-m1-mongo.zip \
+	  app.py handlers storage scripts tests docs README.md requirements.txt .env.example Makefile

--- a/botzilla/README.md
+++ b/botzilla/README.md
@@ -1,0 +1,33 @@
+# BotZilla — Milestone 1 (Mongo)
+
+## What this is
+A Telegram bot skeleton with webhook, onboarding + T&C, MongoDB persistence, admin command, logging, tests.
+
+## Prereqs
+- Python 3.10+
+- MongoDB (local `mongod` or MongoDB Atlas free tier)
+- An internet-exposed HTTPS URL for webhooks (ngrok free tier or Cloudflare Tunnel)
+
+## Setup
+1. python -m venv .venv && source .venv/bin/activate
+2. pip install -r requirements.txt
+3. cp .env.example .env and fill values (see below)
+4. Start MongoDB locally (or provide your Atlas URI in `MONGO_URI`).
+5. Start the app: `make run`
+6. Start tunnel (e.g. ngrok): `ngrok http 5000`
+7. Set Telegram webhook: `BOT_TOKEN=<your token> make set-webhook PUBLIC_URL=https://<your>.ngrok-free.app`
+8. DM your bot `/start` in Telegram. Use `/admin_status` from an admin ID.
+
+## Environment variables
+- **BOT_TOKEN**: Token from BotFather for your bot. Required.
+- **DB_BACKEND**: `mongo` (default) or `sqlite`.
+- **MONGO_URI**: e.g. `mongodb://localhost:27017/botzilla` or your Atlas URI.
+- **SQLITE_PATH**: Only if using SQLite fallback.
+- **ADMIN_IDS**: Comma-separated Telegram user IDs with admin rights.
+- **DEVELOPER_IDS**: Comma-separated Telegram user IDs with developer rights.
+- **PUBLIC_URL**: Your public HTTPS base URL used to register the webhook (e.g., ngrok URL).
+- **LOG_LEVEL**: `INFO` (default), `DEBUG`, etc.
+
+## Make a zip
+- Linux/macOS: `make bundle` → `botzilla-m1-mongo.zip`
+- Windows (PowerShell): `Compress-Archive -Path app.py,handlers,storage,scripts,tests,docs,README.md,requirements.txt,.env.example,Makefile -DestinationPath botzilla-m1-mongo.zip`

--- a/botzilla/app.py
+++ b/botzilla/app.py
@@ -1,0 +1,114 @@
+import os
+import json
+import atexit
+import logging
+import asyncio
+from datetime import datetime
+from flask import Flask, request, jsonify, abort
+from dotenv import load_dotenv
+from telegram import Update
+from telegram.ext import Application
+
+# Local modules
+from storage.sqlite import SQLiteStorage
+try:
+    from storage.mongo import MongoStorage
+except Exception:
+    MongoStorage = None
+from handlers.start import register_start_handlers
+from handlers.admin import register_admin_handlers
+
+load_dotenv()
+
+# ----- Logging (JSON) -----
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        base = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "time": datetime.utcnow().isoformat() + "Z",
+            "logger": record.name,
+        }
+        if record.exc_info:
+            base["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(base)
+
+handler = logging.StreamHandler()
+handler.setFormatter(JsonFormatter())
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), handlers=[handler])
+log = logging.getLogger("botzilla")
+
+# ----- Config -----
+TOKEN = os.getenv("BOT_TOKEN")
+if not TOKEN:
+    raise SystemExit("BOT_TOKEN is required in .env")
+
+DB_BACKEND = os.getenv("DB_BACKEND", "mongo").lower()  # default: mongo
+ADMIN_IDS = {int(x.strip()) for x in os.getenv("ADMIN_IDS", "").split(",") if x.strip()}
+DEVELOPER_IDS = {int(x.strip()) for x in os.getenv("DEVELOPER_IDS", "").split(",") if x.strip()}
+
+# ----- Storage -----
+if DB_BACKEND == "mongo":
+    if not MongoStorage:
+        raise SystemExit("Mongo backend selected but dependencies not available")
+    STORAGE = MongoStorage(os.getenv("MONGO_URI", "mongodb://localhost:27017/botzilla"))
+else:
+    STORAGE = SQLiteStorage(os.getenv("SQLITE_PATH", "botzilla.db"))
+
+# ----- Telegram Application -----
+application = Application.builder().token(TOKEN).build()
+
+# Inject shared state
+application.bot_data["storage"] = STORAGE
+application.bot_data["admin_ids"] = ADMIN_IDS
+application.bot_data["developer_ids"] = DEVELOPER_IDS
+
+# Register handlers
+register_start_handlers(application)
+register_admin_handlers(application)
+
+# ----- Flask App -----
+flask_app = Flask(__name__)
+
+@flask_app.get("/healthz")
+def healthz():
+    return jsonify({"ok": True, "backend": DB_BACKEND}), 200
+
+@flask_app.post("/webhook")
+def webhook():
+    if request.headers.get("content-type") != "application/json":
+        abort(415)
+    data = request.get_json(force=True, silent=True)
+    if not data:
+        abort(400)
+    update = Update.de_json(data, application.bot)
+    # Process the update via PTB in the current thread/event loop
+    asyncio.get_event_loop().run_until_complete(application.process_update(update))
+    return "", 204
+
+# Initialize and start PTB once on startup
+async def _ptb_start():
+    await application.initialize()
+    await application.start()
+    log.info("PTB application started")
+
+async def _ptb_stop():
+    await application.stop()
+    await application.shutdown()
+    log.info("PTB application stopped")
+
+# Ensure proper PTB lifecycle when running this module directly
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_ptb_start())
+
+    def _on_exit():
+        try:
+            loop.run_until_complete(_ptb_stop())
+        except Exception as e:
+            log.error(f"PTB shutdown error: {e}")
+    atexit.register(_on_exit)
+
+    port = int(os.getenv("PORT", 5000))
+    log.info(f"Starting Flask on :{port}")
+    flask_app.run(host="0.0.0.0", port=port)

--- a/botzilla/docs/ImplementationGuide.md
+++ b/botzilla/docs/ImplementationGuide.md
@@ -1,0 +1,51 @@
+# Implementation Guide (Milestone 1)
+
+## Key components
+- **Flask (free, open source):** exposes `/webhook` for Telegram to POST updates.
+- **python-telegram-bot (free, open source):** handles Telegram updates & commands.
+- **MongoDB:** stores user profiles. Use local `mongod` (free) or Atlas (free tier available).
+- **ngrok / Cloudflare Tunnel:** provides a public HTTPS URL to your local app so Telegram can reach it.
+
+## Why a webhook?
+Telegram needs a public HTTPS endpoint to push updates. Polling works too, but webhooks are lower-latency and production-friendly.
+
+## Free vs paid
+- **Flask / python-telegram-bot:** free, permissive licenses.
+- **MongoDB:** free locally; Atlas has a free tier.
+- **ngrok:** has a free tier with a temporary URL (rotates on restart). Alternatives: **Cloudflare Tunnel** (free), **LocalTunnel** (free). Pick any; steps are similar.
+
+## Environment variables explained
+- **BOT_TOKEN:** Secret token Telegram uses to authenticate requests to the Bot API on your behalf. Obtain it from **BotFather**.
+- **DB_BACKEND:** Choose your DB layer. Default is `mongo`.
+- **MONGO_URI:** Connection string to your MongoDB (local or Atlas). Example: `mongodb://localhost:27017/botzilla`.
+- **SQLITE_PATH:** Path to SQLite file if you pick `sqlite` backend (not needed for Mongo).
+- **ADMIN_IDS / DEVELOPER_IDS:** Numeric Telegram user IDs who can access restricted commands. Separate by commas.
+- **PUBLIC_URL:** Public base URL where your app is reachable. Used only when calling `setWebhook`.
+- **LOG_LEVEL:** Controls verbosity of logs.
+
+## How to obtain values
+1. **BOT_TOKEN:** Chat with `@BotFather` in Telegram → `/newbot` → follow prompts → copy the token.
+2. **ADMIN_IDS / DEVELOPER_IDS:** Your numeric Telegram user ID. If you don't know it, start a chat with `@userinfobot` or add a temporary handler to print `update.effective_user.id`.
+3. **MONGO_URI:**
+   - Local: `mongodb://localhost:27017/botzilla` (ensure `mongod` is running).
+   - Atlas: Create a free cluster → get the connection string → replace `<username>`/`<password>`.
+4. **PUBLIC_URL:**
+   - ngrok: run `ngrok http 5000` → copy the generated `https://...ngrok-free.app` URL.
+   - Cloudflare Tunnel: run `cloudflared tunnel --url http://localhost:5000` (see docs), copy the public URL.
+
+## Running locally
+1. Create and activate a venv; install requirements.
+2. Copy `.env.example` → `.env` and fill values.
+3. Run `make run` to start Flask + PTB.
+4. Start your tunnel and set the webhook.
+5. Test `/start` and `/admin_status`.
+
+## Security notes
+- Never commit `.env` with secrets.
+- Logs are JSON and omit secrets by design.
+- Admin commands are gated by ID allowlists.
+
+## Troubleshooting
+- **Webhook not firing:** check tunnel is running and `PUBLIC_URL` matches; verify `/healthz` returns 200.
+- **Mongo connection errors:** ensure `mongod` is running or correct Atlas IP allowlist.
+- **403 on /admin_status:** confirm your Telegram numeric ID is in `ADMIN_IDS`.

--- a/botzilla/handlers/admin.py
+++ b/botzilla/handlers/admin.py
@@ -1,0 +1,30 @@
+from functools import wraps
+from telegram import Update
+from telegram.ext import ContextTypes, CommandHandler
+
+# Role-check decorator
+
+def restricted(role: str = "admin"):
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+            uid = update.effective_user.id
+            admins = context.application.bot_data.get("admin_ids", set())
+            devs = context.application.bot_data.get("developer_ids", set())
+            allowed = (uid in admins) or (role == "developer" and uid in devs)
+            if not allowed:
+                await update.effective_chat.send_message("⛔ This command is restricted.")
+                return
+            return await func(update, context, *args, **kwargs)
+        return wrapper
+    return decorator
+
+@restricted("admin")
+async def status_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    storage = context.application.bot_data["storage"]
+    count = storage.count_users()
+    await update.effective_chat.send_message(f"📊 Users in DB: {count}")
+
+
+def register_admin_handlers(app):
+    app.add_handler(CommandHandler("admin_status", status_cmd))

--- a/botzilla/handlers/start.py
+++ b/botzilla/handlers/start.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes, CommandHandler, CallbackQueryHandler
+
+TC_AGREE = "tc_agree"
+TC_DECLINE = "tc_decline"
+
+WELCOME = (
+    "👋 Welcome to BotZilla!\n\n"
+    "Before we continue, please review and accept our Terms & Conditions to use the bot."
+)
+
+TC_TEXT = (
+    "📄 **Terms & Conditions (summary)**\n\n"
+    "• This bot is for educational use for now.\n"
+    "• You are responsible for your trading decisions.\n"
+    "• We do not store your Telegram messages beyond what’s required for operations.\n\n"
+    "Do you accept?"
+)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    storage = context.application.bot_data["storage"]
+    u = update.effective_user
+    # Upsert user on first interaction
+    storage.upsert_user(
+        telegram_id=u.id,
+        username=(u.username or ""),
+        first_name=(u.first_name or ""),
+        last_name=(u.last_name or ""),
+        profile_pic_url="",  # can be fetched later via getUserProfilePhotos
+        joined_at=datetime.utcnow().isoformat() + "Z",
+        status="unverified",
+    )
+    # Send welcome + T&C
+    kb = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("✅ I Agree", callback_data=TC_AGREE),
+                InlineKeyboardButton("❌ I Do Not Agree", callback_data=TC_DECLINE),
+            ]
+        ]
+    )
+    await update.effective_chat.send_message(WELCOME)
+    await update.effective_chat.send_message(TC_TEXT, reply_markup=kb)
+
+async def on_tc_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    storage = context.application.bot_data["storage"]
+    query = update.callback_query
+    await query.answer()
+
+    if query.data == TC_AGREE:
+        storage.update_status(update.effective_user.id, "verified")
+        await query.edit_message_text("✅ Thanks! You’re verified and ready to go.")
+    else:
+        await query.edit_message_text("❗ Understood. You can /start again anytime.")
+
+# Pure function for tests
+
+def handle_consent(storage, telegram_id: int, agree: bool):
+    if agree:
+        storage.update_status(telegram_id, "verified")
+        return "verified"
+    return "unverified"
+
+
+def register_start_handlers(app):
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CallbackQueryHandler(on_tc_callback, pattern=f"^({TC_AGREE}|{TC_DECLINE})$"))

--- a/botzilla/requirements.txt
+++ b/botzilla/requirements.txt
@@ -1,0 +1,8 @@
+flask>=2.3
+python-telegram-bot>=20.6,<21
+python-dotenv>=1.0
+requests>=2.31
+pydantic>=2.7
+pytest>=8.0
+pytest-asyncio>=0.23
+pymongo>=4.6

--- a/botzilla/scripts/set_webhook.py
+++ b/botzilla/scripts/set_webhook.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import requests
+
+TOKEN = os.getenv("BOT_TOKEN")
+PUBLIC_URL = os.getenv("PUBLIC_URL")  # e.g., https://abcd-1234.ngrok-free.app
+
+if not TOKEN or not PUBLIC_URL:
+    print("BOT_TOKEN and PUBLIC_URL env vars are required", file=sys.stderr)
+    sys.exit(1)
+
+url = f"https://api.telegram.org/bot{TOKEN}/setWebhook"
+resp = requests.post(url, json={"url": f"{PUBLIC_URL}/webhook"})
+print(resp.status_code, resp.text)

--- a/botzilla/storage/mongo.py
+++ b/botzilla/storage/mongo.py
@@ -1,0 +1,27 @@
+from typing import Optional
+from pymongo import MongoClient, ASCENDING
+
+class MongoStorage:
+    def __init__(self, uri: str):
+        self.client = MongoClient(uri)
+        self.db = self.client.get_default_database() or self.client["botzilla"]
+        self.users = self.db["users"]
+        self.users.create_index([("telegram_id", ASCENDING)], unique=True)
+
+    def upsert_user(self, telegram_id: int, username: str, first_name: str, last_name: str,
+                    profile_pic_url: str, joined_at: str, status: str = "unverified") -> None:
+        self.users.update_one(
+            {"telegram_id": telegram_id},
+            {"$setOnInsert": {"joined_at": joined_at, "profile_pic_url": profile_pic_url, "status": status},
+             "$set": {"username": username, "first_name": first_name, "last_name": last_name}},
+            upsert=True,
+        )
+
+    def get_user(self, telegram_id: int) -> Optional[dict]:
+        return self.users.find_one({"telegram_id": telegram_id}, {"_id": 0})
+
+    def update_status(self, telegram_id: int, status: str) -> None:
+        self.users.update_one({"telegram_id": telegram_id}, {"$set": {"status": status}})
+
+    def count_users(self) -> int:
+        return self.users.estimated_document_count()

--- a/botzilla/storage/sqlite.py
+++ b/botzilla/storage/sqlite.py
@@ -1,0 +1,52 @@
+import sqlite3
+from typing import Optional
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+  telegram_id INTEGER PRIMARY KEY,
+  username TEXT,
+  first_name TEXT,
+  last_name TEXT,
+  profile_pic_url TEXT,
+  status TEXT CHECK(status IN ('unverified','verified')) NOT NULL DEFAULT 'unverified',
+  joined_at TEXT NOT NULL,
+  security_hash TEXT
+);
+"""
+
+class SQLiteStorage:
+    def __init__(self, path: str = "botzilla.db"):
+        self.path = path
+        with sqlite3.connect(self.path) as c:
+            c.execute(SCHEMA)
+
+    def upsert_user(self, telegram_id: int, username: str, first_name: str, last_name: str,
+                    profile_pic_url: str, joined_at: str, status: str = "unverified") -> None:
+        with sqlite3.connect(self.path) as c:
+            c.execute(
+                """
+                INSERT INTO users (telegram_id, username, first_name, last_name, profile_pic_url, status, joined_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(telegram_id) DO UPDATE SET
+                  username=excluded.username,
+                  first_name=excluded.first_name,
+                  last_name=excluded.last_name
+                """,
+                (telegram_id, username, first_name, last_name, profile_pic_url, status, joined_at),
+            )
+
+    def get_user(self, telegram_id: int) -> Optional[dict]:
+        with sqlite3.connect(self.path) as c:
+            c.row_factory = sqlite3.Row
+            cur = c.execute("SELECT * FROM users WHERE telegram_id=" + "?" + "", (telegram_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def update_status(self, telegram_id: int, status: str) -> None:
+        with sqlite3.connect(self.path) as c:
+            c.execute("UPDATE users SET status=? WHERE telegram_id=?", (status, telegram_id))
+
+    def count_users(self) -> int:
+        with sqlite3.connect(self.path) as c:
+            cur = c.execute("SELECT COUNT(*) FROM users")
+            return int(cur.fetchone()[0])

--- a/botzilla/tests/test_onboarding.py
+++ b/botzilla/tests/test_onboarding.py
@@ -1,0 +1,21 @@
+import pytest
+from handlers.start import handle_consent
+from storage.sqlite import SQLiteStorage
+
+@pytest.fixture
+def storage(tmp_path):
+    return SQLiteStorage(str(tmp_path / "test.db"))
+
+@pytest.mark.parametrize("agree,expected", [(True, "verified"), (False, "unverified")])
+def test_handle_consent(storage, agree, expected):
+    uid = 42
+    storage.upsert_user(uid, "u", "f", "l", "", "2025-01-01T00:00:00Z")
+    status = handle_consent(storage, uid, agree)
+    assert status == expected
+
+def test_upsert_idempotent(storage):
+    uid = 99
+    storage.upsert_user(uid, "u1", "f1", "l1", "", "2025-01-01T00:00:00Z")
+    storage.upsert_user(uid, "u2", "f2", "l2", "", "2025-01-02T00:00:00Z")
+    user = storage.get_user(uid)
+    assert user["username"] == "u2"


### PR DESCRIPTION
## Summary
- Implement webhook-based Flask app with Mongo or SQLite persistence and JSON logging
- Add user onboarding with Terms & Conditions consent and restricted admin status command
- Include tests, documentation, and Makefile for bundling and setup

## Testing
- `pip install -r requirements.txt` *(failed: Could not connect to proxy)*
- `pytest -q` *(failed: No module named 'handlers')*
- `make bundle`


------
https://chatgpt.com/codex/tasks/task_b_6899b97b00a4832ca0c69c59d23fb812